### PR TITLE
Fix: Quiz Solver

### DIFF
--- a/odinmain/src/main/kotlin/me/odinmain/features/impl/dungeon/puzzlesolvers/QuizSolver.kt
+++ b/odinmain/src/main/kotlin/me/odinmain/features/impl/dungeon/puzzlesolvers/QuizSolver.kt
@@ -33,9 +33,10 @@ object QuizSolver {
     }
 
     fun onMessage(msg: String) {
-        if ((msg.startsWith("[STATUE] Oruo the Omniscient: ") && msg.contains("answered Question #") && msg.endsWith("correctly!")) || msg == "[STATUE] Oruo the Omniscient: I bestow upon you all the power of a hundred years!")
-            triviaOptions.forEach { it.correct = false }
-
+        if (msg.startsWith("[STATUE] Oruo the Omniscient: ") && msg.endsWith("correctly!")) {
+            if (msg.contains("answered the final question")) return reset()
+            if (msg.contains("answered Question #")) triviaOptions.forEach { it.correct = false }
+        }
         if (msg.trim().startsWithOneOf("ⓐ", "ⓑ", "ⓒ", ignoreCase = true)) {
             if (triviaAnswers?.any { msg.endsWith(it) } ?: return) {
                 when (msg.trim()[0]) {

--- a/odinmain/src/main/resources/quizAnswers.json
+++ b/odinmain/src/main/resources/quizAnswers.json
@@ -46,7 +46,7 @@
     "Stable Dragon",
     "Professor Dragon"
   ],
-  "What is the name of the vendor in the Hub who sells stained glass?": ["Wool Weaver"],
+  "What is the name of the vendor in the Hub who sells stained": ["Wool Weaver"],
   "What is the name of the person that upgrades pets?": ["Kat"],
   "Which of these enemies does not spawn in the Spider's Den?": [
     "Zombie Spider",
@@ -56,6 +56,5 @@
     "Broodfather",
     "Night Spider"
   ],
-  "Which of these monsters only spawns at night?": ["Zombie Villager", "Ghast"],
-  "What is the name of the vendor in the Hub who sells stained": ["Wool Weaver"]
+  "Which of these monsters only spawns at night?": ["Zombie Villager", "Ghast"]
 }

--- a/odinmain/src/main/resources/quizAnswers.json
+++ b/odinmain/src/main/resources/quizAnswers.json
@@ -56,5 +56,6 @@
     "Broodfather",
     "Night Spider"
   ],
-  "Which of these monsters only spawns at night?": ["Zombie Villager", "Ghast"]
+  "Which of these monsters only spawns at night?": ["Zombie Villager", "Ghast"],
+  "What is the name of the vendor in the Hub who sells stained": ["Wool Weaver"]
 }


### PR DESCRIPTION
fixes quiz solver waypoints still getting rendered even after finishing quiz, and also adds a missing quiz answer to it

(note: the actual question is 2 messages, so the word "glass" at the end of the question is sent on the next message)