### PR TITLE
Fix: String Rendering Transparency

### DIFF
--- a/odinmain/src/main/kotlin/me/odinmain/utils/render/RenderUtils.kt
+++ b/odinmain/src/main/kotlin/me/odinmain/utils/render/RenderUtils.kt
@@ -340,14 +340,9 @@ object RenderUtils {
     ) {
         val renderPos = getRenderPos(vec3)
 
-        if (!depthTest) {
-            GlStateManager.disableDepth()
-            GlStateManager.depthMask(false)
-        }
+        GlStateManager.pushMatrix()
 
         val xMultiplier = if (mc.gameSettings.thirdPersonView == 2) -1 else 1
-
-        GlStateManager.pushMatrix()
         GlStateManager.translate(renderPos.xCoord, renderPos.yCoord, renderPos.zCoord)
         GlStateManager.rotate(-renderManager.playerViewY, 0.0f, 1.0f, 0.0f)
         GlStateManager.rotate(renderManager.playerViewX * xMultiplier, 1.0f, 0.0f, 0.0f)
@@ -356,16 +351,12 @@ object RenderUtils {
 
         GlStateManager.enableBlend()
         blendFactor()
+        depth(depthTest)
 
         val textWidth = mc.fontRendererObj.getStringWidth(text)
         mc.fontRendererObj.drawString("$text§r", -textWidth / 2f, 0f, color.rgba, shadow)
 
-        if (!depthTest) {
-            GlStateManager.enableDepth()
-            GlStateManager.depthMask(true)
-        }
-
-        GlStateManager.enableLighting()
+        if (!depthTest) resetDepth()
         GlStateManager.disableBlend()
         GlStateManager.resetColor()
         GlStateManager.popMatrix()


### PR DESCRIPTION
fixes string rendering causing some issues with transparency when in third person. some of the modules this can be seen is in dungeon waypoints and blood camp.

see hotbar in the following screenshots
<details>
<summary>Images</summary>

Module disabled:
![image](https://github.com/user-attachments/assets/1459a3fe-dd81-4f01-8b1d-43fe14ea25af)
Module enabled:
![image](https://github.com/user-attachments/assets/bc2bc1ab-32ea-4987-97a7-6ffd870b04e9)
</details>

