### PR TITLE
Build file fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,17 +45,17 @@ allprojects {
 
         implementation("gg.essential:loader-launchwrapper:1.1.3")
         compileOnly("gg.essential:essential-1.8.9-forge:12132+g6e2bf4dc5")
-
-        sourceSets.main {
-            java.srcDir(file("$projectDir/src/main/kotlin"))
-            output.setResourcesDir(sourceSets.main.flatMap { it.java.classesDirectory })
-        }
-
-        java.toolchain.languageVersion.set(JavaLanguageVersion.of(8))
-        kotlin.jvmToolchain(8)
     }
 
     loom {
         forge.pack200Provider.set(Pack200Adapter())
     }
+
+    sourceSets.main {
+        java.srcDir(file("$projectDir/src/main/kotlin"))
+        output.setResourcesDir(sourceSets.main.flatMap { it.java.classesDirectory })
+    }
+
+    java.toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+    kotlin.jvmToolchain(8)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import dev.architectury.pack200.java.Pack200Adapter
+
 plugins {
     idea
     java
@@ -51,5 +53,9 @@ allprojects {
 
         java.toolchain.languageVersion.set(JavaLanguageVersion.of(8))
         kotlin.jvmToolchain(8)
+    }
+
+    loom {
+        forge.pack200Provider.set(Pack200Adapter())
     }
 }

--- a/odin/build.gradle.kts
+++ b/odin/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
         inputs.property("version", version)
 
         filesMatching("mcmod.info") {
-            expand(mapOf("version" to version))
+            expand(inputs.properties)
         }
         dependsOn(compileJava)
     }

--- a/odin/build.gradle.kts
+++ b/odin/build.gradle.kts
@@ -1,4 +1,3 @@
-import dev.architectury.pack200.java.Pack200Adapter
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "me.odin"
@@ -21,7 +20,6 @@ loom {
         }
     }
     forge {
-        pack200Provider.set(Pack200Adapter())
         mixinConfig("mixins.odin.json")
     }
     @Suppress("UnstableApiUsage")

--- a/odinclient/build.gradle.kts
+++ b/odinclient/build.gradle.kts
@@ -1,4 +1,3 @@
-import dev.architectury.pack200.java.Pack200Adapter
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "me.odinclient"
@@ -21,7 +20,6 @@ loom {
         }
     }
     forge {
-        pack200Provider.set(Pack200Adapter())
         mixinConfig("mixins.odinclient.json")
     }
     @Suppress("UnstableApiUsage")

--- a/odinclient/build.gradle.kts
+++ b/odinclient/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
         inputs.property("version", version)
 
         filesMatching("mcmod.info") {
-            expand(mapOf("version" to version))
+            expand(inputs.properties)
         }
         dependsOn(compileJava)
     }
@@ -50,14 +50,14 @@ tasks {
     }
 
     remapJar {
-        archiveBaseName = "OdinClient"
-        input = shadowJar.get().archiveFile
+        archiveBaseName.set("OdinClient")
+        input.set(shadowJar.get().archiveFile)
     }
 
     shadowJar {
         destinationDirectory.set(layout.buildDirectory.dir("archiveJars"))
-        archiveBaseName = "OdinClient"
-        archiveClassifier = "dev"
+        archiveBaseName.set("Odin")
+        archiveClassifier.set("dev")
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         configurations = listOf(shadowImpl)
         mergeServiceFiles()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,5 +18,9 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 rootProject.name = "OdinMod"
 include("odinclient", "odin")


### PR DESCRIPTION
This pull request fixes and improves the gradle build script.
- Fix "No provider for Pack200", explanation below
- Auto download JDK 8 if needed for simpler build process

Since the great refactor (commit 528bcadf783fe2d16020875d0064363b60f7b2b6), the build file has been broken. Only machines that already have the minecraft dependencies cached could compile the mod (including the automated GitHub Actions). This fix allows new machines and forked projects to correctly compile the mod.