### PR TITLE
Requeue disables when someone leaves party after run ends

### DIFF
--- a/src/main/kotlin/me/odinmain/features/impl/dungeon/DungeonRequeue.kt
+++ b/src/main/kotlin/me/odinmain/features/impl/dungeon/DungeonRequeue.kt
@@ -26,7 +26,9 @@ object DungeonRequeue : Module(
             }
 
             runIn(delay * 20) {
-                sendCommand(if (type) "instancerequeue" else "od ${DungeonUtils.floor.name.lowercase()}", clientSide = !type)
+                if (!disableRequeue) {
+                    sendCommand(if (type) "instancerequeue" else "od ${DungeonUtils.floor.name.lowercase()}", clientSide = !type)
+                }
             }
         }
 

--- a/src/main/kotlin/me/odinmain/features/impl/nether/KuudraRequeue.kt
+++ b/src/main/kotlin/me/odinmain/features/impl/nether/KuudraRequeue.kt
@@ -23,12 +23,15 @@ object KuudraRequeue : Module(
                 disableRequeue = false
                 return@onMessage
             }
+
             runIn(delay * 20) {
-                sendCommand("od t${LocationUtils.kuudraTier}", true)
+                if (!disableRequeue) {
+                    sendCommand("od t${LocationUtils.kuudraTier}", true)
+                }
             }
         }
 
-        onMessage(Regex("(\\[.+])? ?(.{1,16}) has left the party.")) {
+        onMessage(Regex("(\\[.+])? ?(.{1,16}) has (left|been removed from) the party.")) {
             if (disablePartyLeave) disableRequeue = true
         }
     }


### PR DESCRIPTION
Fixed dungeon/kuudra requeue still requeueing even after someone leaves the party immediately after a run has ended. Also added check for if player was kicked in kuudra requeue.