### PR TITLE
Fix Ragnarock Axe typo

### DIFF
--- a/src/main/kotlin/me/odinmain/features/ModuleManager.kt
+++ b/src/main/kotlin/me/odinmain/features/ModuleManager.kt
@@ -66,7 +66,7 @@ object ModuleManager {
 
         //skyblock
         NoCursorReset, AutoSprint, BlazeAttunement, ChatCommands, DeployableTimer, DianaHelper, ArrowHit,
-        RagnarokAxe, MobSpawn, Splits, WardrobeKeybinds, InvincibilityTimer, ItemsHighlight, PlayerDisplay,
+        RagnarockAxe, MobSpawn, Splits, WardrobeKeybinds, InvincibilityTimer, ItemsHighlight, PlayerDisplay,
         FarmKeys, PetKeybinds, CommandKeybinds, SpringBoots, AbilityTimers,
 
         // kuudra

--- a/src/main/kotlin/me/odinmain/features/impl/skyblock/RagnarockAxe.kt
+++ b/src/main/kotlin/me/odinmain/features/impl/skyblock/RagnarockAxe.kt
@@ -7,7 +7,7 @@ import me.odinmain.features.settings.impl.BooleanSetting
 import me.odinmain.utils.skyblock.*
 import net.minecraft.network.play.server.S29PacketSoundEffect
 
-object RagnarokAxe : Module(
+object RagnarockAxe : Module(
     name = "Rag Axe",
     description = "Tracks rag axe cooldowns.",
     category = Category.SKYBLOCK
@@ -27,7 +27,7 @@ object RagnarokAxe : Module(
             if (alert) PlayerUtils.alert("§aCasted Rag Axe")
             val strengthGain = ((mc.thePlayer?.heldItem?.getSBStrength ?: return@onPacket) * 1.5).toInt()
             if (strengthGainedMessage) modMessage("§7Gained strength: §4$strengthGain")
-            if (announceStrengthGained) partyMessage("Gained strength from RagnarokAxe: $strengthGain")
+            if (announceStrengthGained) partyMessage("Gained strength from Ragnarock Axe: $strengthGain")
         }
     }
 }


### PR DESCRIPTION
 Hypixel spelt it wrong, changed to match their spelling for both the module and the text sent by Odin