### PR TITLE
Fix: Fresh tools alert

### DIFF
--- a/src/main/kotlin/me/odinmain/features/impl/nether/FreshTimer.kt
+++ b/src/main/kotlin/me/odinmain/features/impl/nether/FreshTimer.kt
@@ -37,7 +37,7 @@ object FreshTimer : Module(
     }
 
     init {
-        onMessage(Regex("Your Fresh Tools Perk bonus doubles your building speed for the next 10 seconds!")) {
+        onMessage(Regex("^Your Fresh Tools Perk bonus doubles your building speed for the next 10 seconds!$")) {
             val teammate = KuudraUtils.kuudraTeammates.find { it.playerName == mc.thePlayer.name } ?: return@onMessage
             teammate.eatFreshTime = System.currentTimeMillis()
             teammate.eatFresh = true


### PR DESCRIPTION
Stops fresh tools regex from being activated on chat messages