### PR TITLE
fix: !coords being inaccurate if it's negative

### DIFF
--- a/src/main/kotlin/me/odinmain/utils/skyblock/PlayerUtils.kt
+++ b/src/main/kotlin/me/odinmain/utils/skyblock/PlayerUtils.kt
@@ -8,6 +8,7 @@ import me.odinmain.utils.render.Color
 import me.odinmain.utils.render.Renderer
 import me.odinmain.utils.ui.Colors
 import net.minecraft.network.play.client.C0EPacketClickWindow
+import net.minecraft.util.BlockPos
 import net.minecraft.util.Vec3
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 
@@ -48,7 +49,10 @@ object PlayerUtils {
     inline val posY get() = mc.thePlayer?.posY ?: 0.0
     inline val posZ get() = mc.thePlayer?.posZ ?: 0.0
 
-    fun getPositionString() = "x: ${posX.toInt()}, y: ${posY.toInt()}, z: ${posZ.toInt()}"
+    fun getPositionString(): String {
+        val blockPos = BlockPos(posX, posY, posZ)
+        return "x: ${blockPos.getX()}, y: ${blockPos.getY()}, z: ${blockPos.getZ()}"
+    }
 
     private var lastClickSent = 0L
 


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/9ae44a21-3c72-42ca-ba68-653122e9a9a7)
