### PR TITLE
better looking tickTask

### DIFF
--- a/src/main/kotlin/me/odinmain/features/ModuleManager.kt
+++ b/src/main/kotlin/me/odinmain/features/ModuleManager.kt
@@ -103,10 +103,10 @@ object ModuleManager {
 
     private fun tickTaskTick(server: Boolean = false) {
         tickTasks.removeIf { tickTask ->
-            if (tickTask.server != server) return@removeAll false
+            if (tickTask.server != server) return@removeIf false
             if (tickTask.ticksLeft <= 0) {
                 runCatching { tickTask.function() }.onFailure { logError(it, this) }
-                return@removeAll true
+                return@removeIf true
             }
             tickTask.ticksLeft--
             false

--- a/src/main/kotlin/me/odinmain/features/ModuleManager.kt
+++ b/src/main/kotlin/me/odinmain/features/ModuleManager.kt
@@ -102,7 +102,7 @@ object ModuleManager {
     }
 
     private fun tickTaskTick(server: Boolean = false) {
-        tickTasks.removeAll { tickTask ->
+        tickTasks.removeIf { tickTask ->
             if (tickTask.server != server) return@removeAll false
             if (tickTask.ticksLeft <= 0) {
                 runCatching { tickTask.function() }.onFailure { logError(it, this) }

--- a/src/main/kotlin/me/odinmain/features/ModuleManager.kt
+++ b/src/main/kotlin/me/odinmain/features/ModuleManager.kt
@@ -111,8 +111,6 @@ object ModuleManager {
             tickTask.ticksLeft--
             false
         }
-
-        if (tasksToRemove.isNotEmpty()) tickTasks.removeAll(tasksToRemove.toSet())
     }
 
     @SubscribeEvent(receiveCanceled = true)


### PR DESCRIPTION
for CopyOnWriteArrayList, removeAll isn't thread-safe while removeIf is

ref: https://stackoverflow.com/questions/51653851/use-cases-of-removeall-and-removeif

my test code:
```kotlin
package org.example

import java.util.concurrent.CopyOnWriteArrayList
import kotlin.system.measureNanoTime

fun getList() = CopyOnWriteArrayList((0..9999).toList())
val tickTasks = getList()

fun main() {
    val t = Thread { removeSomething() }
    println(measureNanoTime {
        t.start()
        removeSomething()
        t.join()
    })
}

fun removeSomething() {
    while (tickTasks.isNotEmpty()) {
        runCatching {
            tickTasks.removeAll { Math.random() < 0.1 }
        }.onFailure {
            println(it.stackTraceToString())
        }
    }
}
``` 