### PR TITLE
Replace distance check with squared distance for optimization

### DIFF
--- a/src/main/kotlin/me/odinmain/events/EventDispatcher.kt
+++ b/src/main/kotlin/me/odinmain/events/EventDispatcher.kt
@@ -26,7 +26,7 @@ object EventDispatcher {
      */
     @SubscribeEvent
     fun onRemoveEntity(event: EntityLeaveWorldEvent) = with(event.entity) {
-        if (inDungeons && this is EntityItem && this.entityItem?.unformattedName?.containsOneOf(dungeonItemDrops, true) != false && mc.thePlayer.getDistanceSqToEntity(this) > 36)
+        if (inDungeons && this is EntityItem && this.entityItem?.unformattedName?.containsOneOf(dungeonItemDrops, true) != false && mc.thePlayer.getDistanceSqToEntity(this) <= 36)
             SecretPickupEvent.Item(this).postAndCatch()
     }
 

--- a/src/main/kotlin/me/odinmain/events/EventDispatcher.kt
+++ b/src/main/kotlin/me/odinmain/events/EventDispatcher.kt
@@ -26,7 +26,7 @@ object EventDispatcher {
      */
     @SubscribeEvent
     fun onRemoveEntity(event: EntityLeaveWorldEvent) = with(event.entity) {
-        if (inDungeons && this is EntityItem && this.entityItem?.unformattedName?.containsOneOf(dungeonItemDrops, true) != false && mc.thePlayer.getDistanceToEntity(this) <= 6)
+        if (inDungeons && this is EntityItem && this.entityItem?.unformattedName?.containsOneOf(dungeonItemDrops, true) != false && mc.thePlayer.getDistanceSqToEntity(this) > 36)
             SecretPickupEvent.Item(this).postAndCatch()
     }
 


### PR DESCRIPTION
This change replaces the distance check from `mc.thePlayer.getDistanceToEntity(this) <= 6` to `mc.thePlayer.getDistanceSqToEntity(this) <= 36`

The reason for this modification is that squared distance comparisons are more efficient and avoid unnecessary square root calculations, which improves performance.
