### PR TITLE
Fix Vesuvius chest detection

### DIFF
--- a/src/main/kotlin/com/odtheking/odin/features/impl/nether/Vesuvius.kt
+++ b/src/main/kotlin/com/odtheking/odin/features/impl/nether/Vesuvius.kt
@@ -13,6 +13,7 @@ import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.Style
 import net.minecraft.network.chat.TextColor
+import net.minecraft.network.protocol.game.ClientboundContainerSetContentPacket
 import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
 import net.minecraft.world.item.ItemStack
@@ -36,7 +37,7 @@ object Vesuvius : Module(
     private val shardRegex = Regex("^([A-Za-z' ]+) Shard(?: x(\\d+))?$")
     private val teethRegex = Regex("^Kuudra Teeth x(\\d+)$")
     private val pearlRegex = Regex("^Heavy Pearl x(\\d+)$")
-    private val chestRegex = Regex("^((Free|Paid) Chest Chest)|(Kuudra - .+)|Vesuvius$")
+    private val chestRegex = Regex("^((Free|Paid) Chest Chest)|(Kuudra - .+)|.*Vesuvius|.*Croesus$")
     private val uselessLinesRegex = Regex("^Contents|Cost|Click to open!|FREE|Already opened!|Can't open another chest!|Paid Chest|")
     private val salvageItemsRegex = Regex("^Boots|Chestplate|Helmet|Cloak|Aurora Staff|Hollow Wand")
 
@@ -67,13 +68,14 @@ object Vesuvius : Module(
         }
 
         on<GuiEvent.RenderSlot> {
-            if (screen.title.string.equalsOneOf("Vesuvius", "Croesus") && slot.item.hoverName.string == "Kuudra's Hollow") {
+            if (screen.title.string.containsOneOf("Vesuvius", "Croesus") && slot.item.hoverName.string == "Kuudra's Hollow") {
                 if (hideClaimed && slot.item.loreString.any { it == "No more chests to open!"}) cancel()
             }
         }
 
+        //Sometimes this gets sent before the screen title gets sent and the regex wouldn't work if you have more than 1 page
         onReceive<ClientboundContainerSetSlotPacket> {
-            val title = mc.screen?.title?.string ?:return@onReceive
+            val title = mc.screen?.title?.string ?: return@onReceive
             if (!title.matches(chestRegex)) return@onReceive
             if (slot == 31 && item.item == Items.CHEST) handleKuudraChest(item)
             if (slot == 14 && item.item == Items.PLAYER_HEAD) handleKuudraChest(item)


### PR DESCRIPTION
## Summary
- recognize paginated Vesuvius and Croesus screen titles
- use partial title matching when hiding claimed Kuudra's Hollow slots

## Testing
- `./gradlew.bat compileKotlin`