### PR TITLE
Update mixin compatibility level to JAVA_25

### DIFF
--- a/src/main/resources/odin.mixins.json
+++ b/src/main/resources/odin.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.odtheking.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "injectors": {
     "defaultRequire": 1
   },


### PR DESCRIPTION
Very small change, was forgotten during 26.1 port I guess. Minecraft 26.1 requires Java 25.